### PR TITLE
Bugfix/CustomDataContainer render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - Fix CredentialsInfoCard, card will not resize when an error occurs in an input, disable `Save` button if hint about wrong input is present, error hint message be cleaned when user click on `Cancel` button (INDIGO 230623, [!41](https://github.com/TeskaLabs/seacat-admin-webui/pull/41))
 
+- CustomDataContainer inital render in edit mode bug. The container only rendered the first item in the list of custom data. (INDIGO Sprint 230623, [!44](https://github.com/TeskaLabs/seacat-admin-webui/pull/44))
+
 ## v23.23-alpha2
 
 Tested with Seacat Auth service [v23.23-beta](https://github.com/TeskaLabs/seacat-auth/releases/tag/v23.23-beta)

--- a/src/modules/auth/components/CustomDataContainer.js
+++ b/src/modules/auth/components/CustomDataContainer.js
@@ -162,7 +162,10 @@ export function CustomDataContainer({app, resources, customData, setCustomData, 
 						title={t("CustomDataContainer|Edit data")}
 						color="primary"
 						outline
-						onClick={() => setEdit(true)}
+						onClick={() => {
+							setEdit(true);
+							append({key: '', value: ''});
+						}}
 						resource={resource}
 						resources={resources}
 						hideOnUnauthorizedAccess={false}


### PR DESCRIPTION
### in this PR

- we tackle inital not rendering of all items in CustomDataContainer after clicking the `Edit` button.
- new, empty line of inputs is added after all prefilled custom data inputs



#### before:

https://github.com/TeskaLabs/seacat-admin-webui/assets/79644454/ee998398-7b30-44e5-a36a-bc7aa05e9b6e


#### after Bugfix:

https://github.com/TeskaLabs/seacat-admin-webui/assets/79644454/661bbd4d-6788-4824-bcc2-e11c43a7c298

