### PR TITLE
Add parameter last_login to obtain last login info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Release Candidate
 
+### Compatibility
+
+To display last successful and unsuccessful login information, Seacat Auth service [v23.26-beta](https://github.com/TeskaLabs/seacat-auth/releases/tag/v23.26-beta) and newer must be used.
+
 ### Features
 
 - ASAB WebUI submodule version bump [[3a35738](https://github.com/TeskaLabs/asab-webui/commit/3a3573806e2964efbf5e5bb02c15acc9af41c8ac)] commit (INDIGO Sprint 230609, [!40](https://github.com/TeskaLabs/seacat-admin-webui/pull/40))
@@ -9,6 +13,8 @@
 ### Refactoring
 
 - Changed button title from "Create New Credentials" to "New Credentials". (INDIGO 230609, [!42](https://github.com/TeskaLabs/seacat-admin-webui/pull/42))
+
+- Add parameter `last_login=yes` to `GET /credentials/{cred_id}` endpoint to retrieve last login info. (INDIGO 230623, [!45](https://github.com/TeskaLabs/seacat-admin-webui/pull/45))
 
 ### Bugfix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Compatibility
 
-To display last successful and unsuccessful login information, Seacat Auth service [v23.26-beta](https://github.com/TeskaLabs/seacat-auth/releases/tag/v23.26-beta) and newer must be used.
+To display last successful and unsuccessful login information, Seacat Auth service [v23.27-beta](https://github.com/TeskaLabs/seacat-auth/releases/tag/v23.27-beta) and newer must be used.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Release Candidate
 
+## v23.27-beta
+
 ### Compatibility
 
 To display last successful and unsuccessful login information, Seacat Auth service [v23.27-beta](https://github.com/TeskaLabs/seacat-auth/releases/tag/v23.27-beta) and newer must be used.

--- a/src/modules/auth/credentials/CredentialsDetailContainer.js
+++ b/src/modules/auth/credentials/CredentialsDetailContainer.js
@@ -62,7 +62,7 @@ function CredentialsDetailContainer(props) {
 
 	const retrieveData = async () => {
 		try {
-			let response = await SeaCatAuthAPI.get(`/credentials/${credentials_id}`);
+			let response = await SeaCatAuthAPI.get(`/credentials/${credentials_id}?last_login=yes`);
 			setData(response.data);
 			setSuspended(response.data.suspended);
 			setProviderID(response.data._provider_id);


### PR DESCRIPTION
- add parameter `last_login=yes` to `GET /credentials/{cred_id}` endpoint to retrieve last login info

Dependant on:

https://github.com/TeskaLabs/seacat-auth/pull/219