### PR TITLE
Refactor/Bulk-Assignment-Spacing-Update

### DIFF
--- a/src/modules/auth/credentials/credentials.scss
+++ b/src/modules/auth/credentials/credentials.scss
@@ -189,17 +189,16 @@
 
 // BULK ASSIGNMENT
 .bulk-actions-wraper {
-    display: grid;
-    grid-template-areas:
-        "a a c c"
-        "a a c c"
-		"b b d d"
-		"b b d d";
-
-    grid-template-rows: 1fr 1fr 1fr 1fr;
-	grid-template-columns: 1fr 1fr 1fr 1fr;
-    column-gap: 0.25rem;
-    row-gap: 0.25rem;
+	display: grid;
+	grid-template-areas:
+		"a a e e c c"
+		"a a e e c c"
+		"b b f f d d"
+		"b b f f d d";
+	grid-template-rows: 1fr 1fr 1fr 1fr;
+	grid-template-columns: 1fr 1fr auto auto 1fr 1fr;
+	column-gap: 0.25rem;
+	row-gap: 0.25rem;
 	& .card-body {
 		height: 35vh !important;
 		overflow-y: auto;


### PR DESCRIPTION
### In This PR

- spacing update in bulk assignment screen.  empty collumn between tenant selection cards matches the space created by bulk action buttons between credentials selection

<img width="1218" alt="Screenshot 2023-07-21 at 16 28 13" src="https://github.com/TeskaLabs/seacat-admin-webui/assets/79644454/e2b112c6-be1c-482b-9ad1-1ace44cd759c">
